### PR TITLE
fix: Added explicit dependencies for ament_cmake_ros and gtest_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc videoio)
+find_package(gtest_vendor)
 
 add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/utils.cpp

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,9 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>libopencv-dev</build_depend>
 
+  <depend>ament_cmake_ros</depend>
+  <depend>gtest_vendor</depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>


### PR DESCRIPTION
Fix regression on ROS 2 Buildfarm for Rolling

This PR addresses [issue #5](https://github.com/tuw-robotics/tuw_geometry/issues/5#issue-2994346495) by adding explicit dependencies on `ament_cmake_ros` and `gtest_vendor`.  

Changes made:
- Added `find_package(gtest_vendor)` to CMakeLists.txt
- Added `<depend>ament_cmake_ros</depend>` and `<depend>gtest_vendor</depend>` to package.xml



These changes should fix the build error reported in the Rolling buildfarm logs:
https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__tuw_geometry__ubuntu_noble_amd64__binary/61/console