### PR TITLE
Fix regression: add gtest_vendor and ament_cmake_ros dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(include)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+find_package(gtest_vendor REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)


### PR DESCRIPTION
Fixes [#5](https://github.com/tuw-robotics/tuw_geometry/issues/5)
This patch adds missing dependencies gtest_vendor and ament_cmake_ros to fix the Rolling regression.